### PR TITLE
Add an option for pausing videos when they are loaded

### DIFF
--- a/data/youtube-video-quality.js
+++ b/data/youtube-video-quality.js
@@ -22,9 +22,13 @@ var ensureYTParameters = function(event) {
                 player.wrappedJSObject.setPlaybackQuality(self.options.settings["yt-video-quality"]);
             }
             player.wrappedJSObject.pauseVideo();
-            setTimeout(function() {
-                player.wrappedJSObject.playVideo();
-            }, 200);
+
+            // let the user play the video if yt-start-paused is true
+            if(!self.options.settings["yt-start-paused"]) {
+                setTimeout(function() {
+                    player.wrappedJSObject.playVideo();
+                }, 200);
+            }
         }
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,7 @@ exports.main = function(options) {
     settings["yt-disable-spf"] = simplePrefs.prefs["yt-disable-spf"];
     settings["yt-disable-flash"] = simplePrefs.prefs["yt-disable-flash"];
     settings["yt-fix-volume"] = simplePrefs.prefs["yt-fix-volume"];
+    settings["yt-start-paused"] = simplePrefs.prefs["yt-start-paused"];
 
     // youtube button
     pageMod.PageMod({

--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
       "type": "bool",
       "value": false
   }, {
+      "name": "yt-start-paused",
+      "title": "Start videos paused on YouTube",
+      "description": "This pauses videos when they are loaded",
+      "type": "bool",
+      "value": false
+  }, {
       "name": "yt-loadtype",
       "title": "YouTube video loading method",
       "description": "Note: The button always uses the API method on first click and the embedding method on second click.",


### PR DESCRIPTION
A boolean setting and appropriate text in package.json, loaded by main.js, for use in youtube-video-quality.js, to decide if playVideo() should be called after pauseVideo().

The default value is false, which maintains the current behaviour of playing the video automatically.

Implements issue #14.
