### PR TITLE
Set unsafe-content-script to true in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "author": "Klemens Schölhorn",
   "icon": "logo/logo32.png",
   "icon64": "logo/logo64.png",
-  "permissions": { "private-browsing": true },
+  "permissions": { "private-browsing": true,
+                   "unsafe-content-script": true },
   "license": "GPLv3",
-  "version": "2.1.1",
+  "version": "2.1.1.1",
   "preferences": [{
       "name": "resolution",
       "title": "YouTube video size",


### PR DESCRIPTION
I patched the addon according to https://blog.mozilla.org/addons/2014/04/10/changes-to-unsafewindow-for-the-add-on-sdk/ as you advised in https://github.com/klemens/ff-youtube-all-html5/issues/26 for an interim solution for this issue.

Feel free to ignore it if the real fix is ready soon.
