### PR TITLE
youtube-nocookie

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,7 +12,7 @@ const IEUserAgent = "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident
 var youtubeIE = new UserAgentChanger("www.youtube.com", IEUserAgent);
 var youtubeFlash = new PluginPermissionChanger("http://www.youtube.com", "flash");
 var youtubeEmbedFlash = new URIChanger(function(uri) {
-    if("www.youtube.com" !== uri.host ||
+    if(("www.youtube.com" !== uri.host && "www.youtube-nocookie.com" !== uri.host) ||
        "/embed/" !== uri.path.substr(0,7) ||
        -1 !== uri.path.indexOf("html5=1")) {
         return null;


### PR DESCRIPTION
Add html5 video to embedded video also from youtube-nocookie, official "privacy-enhanced" mirror.
