### PR TITLE
parse url-anchor for time if it fits the pattern

### DIFF
--- a/data/youtube-html5.js
+++ b/data/youtube-html5.js
@@ -316,7 +316,13 @@ function youtubeHtml5ButtonLoader(startOptions) {
         window.location.search.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(str, key, value) {
             params[key] = value;
         });
-        return params;
+	
+	// parse url-anchors for time (#t=...) separately as they slip through above code
+	var hash = window.location.hash.substring(1);
+	if( /^t=[0-9]*h?[0-9]*m?[0-9]*s?$/.test(hash) ) {
+	    params["t"] = hash.substring(2);
+        }
+	return params;
     }
 
     function dispatchEvent(type, detail) {


### PR DESCRIPTION
This patch fixes https://github.com/klemens/ff-youtube-all-html5/issues/40. (Edit: Not really)

I tested it with the working version 2.1.3 distributed on the mozilla addon store (unpacked, changed, repacked).
